### PR TITLE
Always prompt for nickname on start

### DIFF
--- a/Assets/Scenes/Intro.unity
+++ b/Assets/Scenes/Intro.unity
@@ -552,7 +552,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Enter text...
+  m_Text: Pseudo
 --- !u!222 &1164441630
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -673,9 +673,9 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 'Hello!
+  m_Text: 'Bonjour!
 
-    Please enter a nickname to use in online races.'
+    S''il te plaît entre ton pseudo INTRANET JVLAN.'
 --- !u!222 &1630712231
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Startup.cs
+++ b/Assets/Scripts/Startup.cs
@@ -22,15 +22,12 @@ namespace Sanicball
 
         private void Start()
         {
-            if (string.IsNullOrEmpty(ActiveData.GameSettings.nickname) || ActiveData.GameSettings.nickname == "Player")
+            // Always prompt for a nickname on startup and prefill if one exists
+            setNicknameGroup.alpha = 1f;
+            intro.enabled = false;
+            if (nicknameField != null)
             {
-                //Set nickname before continuing
-                setNicknameGroup.alpha = 1f;
-            }
-            else
-            {
-                setNicknameGroup.alpha = 0f;
-                intro.enabled = true;
+                nicknameField.text = ActiveData.GameSettings.nickname ?? string.Empty;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Always show nickname dialog on startup and reset input
- Localize intro greeting and placeholder text to French
- Prefill dialog with existing nickname if one has been set

## Testing
- `mcs Assets/Scripts/Startup.cs` *(fails: missing Unity assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_68a271b1d46c8325a4ba1cb435ec446b