### PR TITLE
Prevent backward glitching after respawn

### DIFF
--- a/Assets/Scripts/Logic/RacePlayer.cs
+++ b/Assets/Scripts/Logic/RacePlayer.cs
@@ -72,9 +72,7 @@ namespace Sanicball.Logic
         //Backward movement check
         private float backwardTimer;
         private bool backwardCheckActive;
-        private Vector3 checkpointForward;
-        private Vector3 respawnPosition;
-        private Rigidbody rb;
+        private float closestDistanceToNextCheckpoint;
 
         //Events
         public event EventHandler<NextCheckpointPassArgs> NextCheckpointPassed;
@@ -122,7 +120,6 @@ namespace Sanicball.Logic
             ball.RespawnRequested += Ball_RespawnRequested;
             currentCheckpointPos = sr.checkpoints[0].transform.position;
             this.ball = ball;
-            rb = ball.GetComponent<Rigidbody>();
             backwardTimer = 0f;
             backwardCheckActive = false;
 
@@ -289,8 +286,7 @@ namespace Sanicball.Logic
             }
 
             //Prepare backward movement check
-            respawnPosition = sr.checkpoints[currentCheckpointIndex].transform.position;
-            checkpointForward = sr.checkpoints[currentCheckpointIndex].transform.forward;
+            closestDistanceToNextCheckpoint = Vector3.Distance(ball.transform.position, nextCheckpoint.transform.position);
             backwardTimer = 0f;
             backwardCheckActive = true;
 
@@ -339,9 +335,8 @@ namespace Sanicball.Logic
 
             if (backwardCheckActive)
             {
-                Vector3 toBall = ball.transform.position - respawnPosition;
-                float dot = Vector3.Dot(toBall, checkpointForward);
-                if (dot < 0f)
+                float currentDistance = Vector3.Distance(ball.transform.position, nextCheckpoint.transform.position);
+                if (currentDistance > closestDistanceToNextCheckpoint + 1f)
                 {
                     backwardTimer += dt;
                     if (backwardTimer >= 10f)
@@ -352,6 +347,12 @@ namespace Sanicball.Logic
                         if (WrongWayRespawned != null)
                             WrongWayRespawned(this, EventArgs.Empty);
                     }
+                }
+                else
+                {
+                    backwardTimer = 0f;
+                    if (currentDistance < closestDistanceToNextCheckpoint)
+                        closestDistanceToNextCheckpoint = currentDistance;
                 }
             }
         }

--- a/Assets/Scripts/Logic/RacePlayer.cs
+++ b/Assets/Scripts/Logic/RacePlayer.cs
@@ -339,7 +339,7 @@ namespace Sanicball.Logic
                 if (currentDistance > closestDistanceToNextCheckpoint + 1f)
                 {
                     backwardTimer += dt;
-                    if (backwardTimer >= 10f)
+                    if (backwardTimer >= 3f)
                     {
                         backwardCheckActive = false;
                         backwardTimer = 0f;

--- a/Assets/Scripts/Logic/RacePlayer.cs
+++ b/Assets/Scripts/Logic/RacePlayer.cs
@@ -73,6 +73,7 @@ namespace Sanicball.Logic
         private float backwardTimer;
         private bool backwardCheckActive;
         private Vector3 checkpointForward;
+        private Vector3 respawnPosition;
         private Rigidbody rb;
 
         //Events
@@ -288,9 +289,8 @@ namespace Sanicball.Logic
             }
 
             //Prepare backward movement check
-            Vector3 currentPos = sr.checkpoints[currentCheckpointIndex].transform.position;
-            Vector3 nextPos = nextCheckpoint.transform.position;
-            checkpointForward = (nextPos - currentPos).normalized;
+            respawnPosition = sr.checkpoints[currentCheckpointIndex].transform.position;
+            checkpointForward = sr.checkpoints[currentCheckpointIndex].transform.forward;
             backwardTimer = 0f;
             backwardCheckActive = true;
 
@@ -339,7 +339,8 @@ namespace Sanicball.Logic
 
             if (backwardCheckActive)
             {
-                float dot = Vector3.Dot(rb.velocity, checkpointForward);
+                Vector3 toBall = ball.transform.position - respawnPosition;
+                float dot = Vector3.Dot(toBall, checkpointForward);
                 if (dot < 0f)
                 {
                     backwardTimer += dt;
@@ -351,10 +352,6 @@ namespace Sanicball.Logic
                         if (WrongWayRespawned != null)
                             WrongWayRespawned(this, EventArgs.Empty);
                     }
-                }
-                else
-                {
-                    backwardTimer = 0f;
                 }
             }
         }

--- a/Assets/Scripts/UI/PlayerUI.cs
+++ b/Assets/Scripts/UI/PlayerUI.cs
@@ -60,6 +60,7 @@ namespace Sanicball.UI
                 {
                     targetPlayer.NextCheckpointPassed -= TargetPlayer_NextCheckpointPassed;
                     targetPlayer.Respawned -= TargetPlayer_Respawned;
+                    targetPlayer.WrongWayRespawned -= TargetPlayer_WrongWayRespawned;
                     Destroy(checkpointMarker.gameObject);
                     foreach (Marker m in playerMarkers)
                     {
@@ -71,6 +72,7 @@ namespace Sanicball.UI
 
                 targetPlayer.NextCheckpointPassed += TargetPlayer_NextCheckpointPassed;
                 targetPlayer.Respawned += TargetPlayer_Respawned;
+                targetPlayer.WrongWayRespawned += TargetPlayer_WrongWayRespawned;
 
                 //Marker following next checkpoint
                 checkpointMarker = Instantiate(markerPrefab);
@@ -117,7 +119,7 @@ namespace Sanicball.UI
         }
 
         public Camera TargetCamera { get; set; }
-        
+
         private void TargetPlayer_Respawned(object sender, EventArgs e)
         {
             UISound.Play(respawnSound);
@@ -128,6 +130,30 @@ namespace Sanicball.UI
             checkpointTimeDiffField.color = Color.red;
             checkpointTimeDiffField.text = "+" + Utils.GetTimeString(TimeSpan.FromSeconds(5));
             checkpointTimeDiffField.GetComponent<ToggleCanvasGroup>().ShowTemporarily(2f);
+        }
+
+        private void TargetPlayer_WrongWayRespawned(object sender, EventArgs e)
+        {
+            var go = new GameObject("WrongWayMessage");
+            go.transform.SetParent(fieldContainer, false);
+
+            var text = go.AddComponent<Text>();
+            text.font = checkpointTimeField.font;
+            text.text = "Chez nous pas de glich de ce style :) pas fair play!";
+            text.alignment = TextAnchor.MiddleCenter;
+            text.fontSize = 48;
+            text.color = Color.red;
+
+            var rect = text.GetComponent<RectTransform>();
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+
+            go.AddComponent<CanvasGroup>();
+            var toggle = go.AddComponent<ToggleCanvasGroup>();
+            toggle.ShowTemporarily(3f);
+            Destroy(go, 3f);
         }
 
         private void TargetPlayer_NextCheckpointPassed(object sender, NextCheckpointPassArgs e)


### PR DESCRIPTION
## Summary
- Detect when a racer moves backward for over 10 seconds after respawning and send them back to the checkpoint
- Display a large warning message on repeated respawn: "Chez nous pas de glich de ce style :) pas fair play!"

## Testing
- ⚠️ `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a28119a1608325817b9881273fd113