### PR TITLE
Add new balls 15-17 to selector and server tiers

### DIFF
--- a/Assets/Scripts/UI/CharacterSelectPanel.cs
+++ b/Assets/Scripts/UI/CharacterSelectPanel.cs
@@ -51,20 +51,36 @@ namespace Sanicball.UI
 
         private IEnumerator Start()
         {
-            var charList = ActiveData.Characters.OrderBy(a => a.tier).ToArray();
+            var charList = ActiveData.Characters
+                .Select((c, index) => new { Char = c, Index = index })
+                .OrderBy(x => x.Char.tier)
+                .ThenBy(x => x.Index)
+                .ToList();
+
+            //Move new balls (15, 16, 17) directly after the first three characters
+            int insertPos = 3;
+            foreach (int specialIndex in new[] { 15, 16, 17 })
+            {
+                var item = charList.FirstOrDefault(x => x.Index == specialIndex);
+                if (item != null)
+                {
+                    charList.Remove(item);
+                    charList.Insert(insertPos++, item);
+                }
+            }
 
             CharacterSelectEntry cancelEnt = Instantiate(entryPrefab);
             cancelEnt.IconImage.sprite = cancelIconSprite;
             cancelEnt.transform.SetParent(entryContainer.transform, false);
             activeEntries.Add(cancelEnt);
 
-            for (int i = 0; i < charList.Length; i++)
+            foreach (var entry in charList)
             {
-                if (!charList[i].hidden)
+                if (!entry.Char.hidden)
                 {
                     CharacterSelectEntry characterEnt = Instantiate(entryPrefab);
 
-                    characterEnt.Init(charList[i]);
+                    characterEnt.Init(entry.Char);
                     characterEnt.transform.SetParent(entryContainer.transform, false);
                     activeEntries.Add(characterEnt);
                 }

--- a/Subprojects/Core/Server/Server.cs
+++ b/Subprojects/Core/Server/Server.cs
@@ -70,8 +70,11 @@ namespace SanicballCore.Server
             CharacterTier.Normal,       //Bloze
             CharacterTier.Normal,       //Vactor
             CharacterTier.Hyperspeed,   //Super Sanic
-            CharacterTier.Odd,       //Metal Sanic
+            CharacterTier.Odd,          //Metal Sanic
             CharacterTier.Odd,          //Ogre
+            CharacterTier.Normal,       //Ball 15
+            CharacterTier.Normal,       //Ball 16
+            CharacterTier.Normal,       //Ball 17
         };
 
         public event EventHandler<LogArgs> OnLog;


### PR DESCRIPTION
## Summary
- Ensure newly added balls 15, 16, and 17 appear directly beneath characters 01–03 in the selection menu
- Expand server character tier list to include IDs 15, 16, and 17 so they are recognized during play

## Testing
- `xbuild Subprojects/Core/SanicballCore.csproj` *(fails: Reference 'UnityEngine' not resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a344a864708325b4354538cc368278