### PR TITLE
Export race results to text file

### DIFF
--- a/Subprojects/Core/Server/ServPlayer.cs
+++ b/Subprojects/Core/Server/ServPlayer.cs
@@ -17,6 +17,11 @@ namespace SanicballCore.Server
         public Stopwatch RacingTimeout { get; }
         public bool TimeoutMessageSent { get; set; }
 
+        //Race result data
+        public double? RaceTime { get; set; }
+        public int? FinishPosition { get; set; }
+        public bool Disqualified { get; set; }
+
         public ServPlayer(Guid clientGuid, ControlType ctrlType, int initialCharacterId)
         {
             RacingTimeout = new Stopwatch();


### PR DESCRIPTION
## Summary
- track race results on server and write them to a timestamped text file per map
- store player finish time and placement for exporting

## Testing
- `dotnet build Subprojects/Server/SanicballServer.csproj` *(fails: The reference assemblies for .NETFramework, Version=v3.5 were not found)*
- `xbuild Subprojects/Server/SanicballServer.csproj` *(fails: Reference 'UnityEngine' not resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a35e8c30fc832583c1c19f38734e88