### PR TITLE
Fix join server input fields not editable at high resolution

### DIFF
--- a/Assets/Prefabs/User Interface/Popups/JoinServerPopup.prefab
+++ b/Assets/Prefabs/User Interface/Popups/JoinServerPopup.prefab
@@ -422,8 +422,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -709,7 +709,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []


### PR DESCRIPTION
## Summary
- prevent join server popup's background panel from intercepting clicks so IP and port fields stay usable at high resolutions

## Testing
- `xbuild Subprojects/Core/SanicballCore.csproj` *(fails: Reference 'UnityEngine' not resolved)*
- `xbuild Subprojects/Server/SanicballServer.csproj` *(fails: Reference 'UnityEngine' not resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a35f1859608325b1af21cc42f240e7