### PR TITLE
Fix join server input fields at high resolutions

### DIFF
--- a/Assets/Scripts/UI/PopupJoinServer.cs
+++ b/Assets/Scripts/UI/PopupJoinServer.cs
@@ -16,6 +16,16 @@ namespace Sanicball.UI
         private const int LOWEST_PORT_NUM = 1024;
         private const int HIGHEST_PORT_NUM = 49151;
 
+        private void OnEnable()
+        {
+            // Ensure input fields remain usable on high resolutions where
+            // they might lose focus or become non-interactable.
+            ipInput.interactable = true;
+            portInput.interactable = true;
+            ipInput.Select();
+            ipInput.ActivateInputField();
+        }
+
         public void Connect()
         {
             portOutput.text = "";


### PR DESCRIPTION
## Summary
- ensure join server IP and port fields stay interactable and focused when popup opens

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a35f1859608325b1af21cc42f240e7