### PR TITLE
Handle missing server list URL in online menu

### DIFF
--- a/Assets/Scripts/Data/ActiveData.cs
+++ b/Assets/Scripts/Data/ActiveData.cs
@@ -39,6 +39,8 @@ namespace Sanicball.Data
 
         #region Properties
 
+        public static ActiveData Instance { get { return instance; } }
+
         public static GameSettings GameSettings { get { return instance.gameSettings; } }
         public static KeybindCollection Keybinds { get { return instance.keybinds; } }
         public static MatchSettings MatchSettings { get { return instance.matchSettings; } set { instance.matchSettings = value; } }
@@ -85,6 +87,7 @@ namespace Sanicball.Data
         public void LoadAll()
         {
             Load("GameSettings.json", ref gameSettings);
+            gameSettings.Validate();
             Load("GameKeybinds.json", ref keybinds);
             Load("MatchSettings.json", ref matchSettings);
             Load("Records.json", ref raceRecords);
@@ -96,6 +99,14 @@ namespace Sanicball.Data
             Save("GameKeybinds.json", keybinds);
             Save("MatchSettings.json", matchSettings);
             Save("Records.json", raceRecords);
+        }
+
+        public static void SaveAllData()
+        {
+            if (instance != null)
+            {
+                instance.SaveAll();
+            }
         }
 
         private void Load<T>(string filename, ref T output)

--- a/Assets/Scripts/Data/GameSettings.cs
+++ b/Assets/Scripts/Data/GameSettings.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace Sanicball.Data
 {
@@ -6,8 +7,10 @@ namespace Sanicball.Data
     public class GameSettings
     {
         [Header("Online")]
+        public const string DefaultServerListUrl = "https://sanicball.bdgr.zone/servers/";
+
         public string nickname = "";
-		public string serverListURL = "https://sanicball.bdgr.zone/servers/";
+        public string serverListURL = DefaultServerListUrl;
 
         public string gameJoltUsername;
         public string gameJoltToken;
@@ -49,7 +52,7 @@ namespace Sanicball.Data
         public void CopyValues(GameSettings original)
         {
             nickname = original.nickname;
-			serverListURL = original.serverListURL;
+            serverListURL = original.serverListURL;
             gameJoltUsername = original.gameJoltUsername;
             gameJoltToken = original.gameJoltToken;
 
@@ -94,6 +97,25 @@ namespace Sanicball.Data
             oldControlsKbSpeed = Mathf.Clamp(oldControlsKbSpeed, 0.5f, 10f);
             //Sound volume
             soundVolume = Mathf.Clamp(soundVolume, 0f, 1f);
+
+            //Server browser URL
+            if (string.IsNullOrWhiteSpace(serverListURL))
+            {
+                serverListURL = DefaultServerListUrl;
+            }
+            else
+            {
+                var trimmedUrl = serverListURL.Trim();
+                Uri parsedUri;
+                if (Uri.TryCreate(trimmedUrl, UriKind.Absolute, out parsedUri))
+                {
+                    serverListURL = trimmedUrl;
+                }
+                else
+                {
+                    serverListURL = DefaultServerListUrl;
+                }
+            }
         }
 
         public void Apply(bool changeWindow)

--- a/Assets/Scripts/Startup.cs
+++ b/Assets/Scripts/Startup.cs
@@ -12,10 +12,12 @@ namespace Sanicball
 
         public void ValidateNickname()
         {
-            if (nicknameField.text.Trim() != "")
+            var trimmed = nicknameField.text.Trim();
+            if (trimmed != "")
             {
                 setNicknameGroup.alpha = 0f;
-                ActiveData.GameSettings.nickname = nicknameField.text;
+                ActiveData.GameSettings.nickname = trimmed;
+                ActiveData.SaveAllData();
                 intro.enabled = true;
             }
         }

--- a/Assets/Scripts/UI/OnlinePanel.cs
+++ b/Assets/Scripts/UI/OnlinePanel.cs
@@ -35,10 +35,40 @@ namespace Sanicball.UI
             discoveryClient.DiscoverLocalPeers(25000);
             latestLocalRefreshTime = DateTime.Now;
 
-			serverBrowserRequester = new WWW(ActiveData.GameSettings.serverListURL);
+            var serverListUrl = ActiveData.GameSettings.serverListURL;
+            serverListUrl = string.IsNullOrWhiteSpace(serverListUrl) ? string.Empty : serverListUrl.Trim();
 
-            serverCountField.text = "Refreshing servers, hang on...";
-            errorField.enabled = false;
+            bool requestedBrowser = false;
+
+            if (string.IsNullOrEmpty(serverListUrl))
+            {
+                serverBrowserRequester = null;
+                errorField.enabled = true;
+                errorField.text = "Server list URL is empty. Update it in Options > Online.";
+                serverCountField.text = "Showing LAN servers only.";
+            }
+            else
+            {
+                try
+                {
+                    serverBrowserRequester = new WWW(serverListUrl);
+                    requestedBrowser = true;
+                }
+                catch (Exception ex)
+                {
+                    serverBrowserRequester = null;
+                    errorField.enabled = true;
+                    errorField.text = "Server list URL is invalid. Update it in Options > Online.";
+                    serverCountField.text = "Cannot access server list URL!";
+                    Debug.LogError("Failed to request servers from '" + serverListUrl + "' - " + ex.Message);
+                }
+            }
+
+            if (requestedBrowser)
+            {
+                serverCountField.text = "Refreshing servers, hang on...";
+                errorField.enabled = false;
+            }
 
             //Clear old servers
             foreach (var serv in servers)

--- a/Assets/Scripts/UI/OptionsPanel.cs
+++ b/Assets/Scripts/UI/OptionsPanel.cs
@@ -43,8 +43,11 @@ namespace Sanicball.UI
 
         public void Apply()
         {
+            tempSettings.Validate();
             ActiveData.GameSettings.CopyValues(tempSettings);
+            ActiveData.GameSettings.Validate();
             ActiveData.GameSettings.Apply(true);
+            ActiveData.SaveAllData();
         }
 
         public void RevertToCurrent()


### PR DESCRIPTION
## Summary
- add a default constant and validation for the server browser URL in `GameSettings`
- validate loaded and applied settings so the URL is restored when blank or malformed
- guard the online server refresh logic against missing URLs and surface user-friendly errors
- trim nickname input and save updated settings immediately so the player's name is always persisted

## Testing
- not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ceceab0c2c8325bc658f6d7f654ce9