### PR TITLE
Persist nickname and settings immediately

### DIFF
--- a/Assets/Scripts/Data/ActiveData.cs
+++ b/Assets/Scripts/Data/ActiveData.cs
@@ -85,6 +85,8 @@ namespace Sanicball.Data
         public void LoadAll()
         {
             Load("GameSettings.json", ref gameSettings);
+            gameSettings.Validate();
+            SaveGameSettings();
             Load("GameKeybinds.json", ref keybinds);
             Load("MatchSettings.json", ref matchSettings);
             Load("Records.json", ref raceRecords);
@@ -143,6 +145,17 @@ namespace Sanicball.Data
                 sw.Write(data);
             }
             Debug.Log(filename + " saved successfully.");
+        }
+
+        public static void SaveGameSettings()
+        {
+            if (instance == null)
+            {
+                Debug.LogWarning("Tried to save game settings before ActiveData was initialized.");
+                return;
+            }
+
+            instance.Save("GameSettings.json", instance.gameSettings);
         }
 
         #endregion Saving and loading

--- a/Assets/Scripts/Data/GameJoltInfo.cs
+++ b/Assets/Scripts/Data/GameJoltInfo.cs
@@ -117,6 +117,7 @@ namespace Sanicball.Data
                 //Not legit! Remove info
                 ActiveData.GameSettings.gameJoltUsername = string.Empty;
                 ActiveData.GameSettings.gameJoltToken = string.Empty;
+                ActiveData.SaveGameSettings();
             }
             GJAPI.Users.VerifyCallback -= CheckIfSignedInCallback;
         }

--- a/Assets/Scripts/Data/GameSettings.cs
+++ b/Assets/Scripts/Data/GameSettings.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace Sanicball.Data
 {
@@ -6,8 +7,10 @@ namespace Sanicball.Data
     public class GameSettings
     {
         [Header("Online")]
+        public const string DefaultServerListUrl = "https://sanicball.bdgr.zone/servers/";
+
         public string nickname = "";
-		public string serverListURL = "https://sanicball.bdgr.zone/servers/";
+        public string serverListURL = DefaultServerListUrl;
 
         public string gameJoltUsername;
         public string gameJoltToken;
@@ -49,7 +52,7 @@ namespace Sanicball.Data
         public void CopyValues(GameSettings original)
         {
             nickname = original.nickname;
-			serverListURL = original.serverListURL;
+            serverListURL = original.serverListURL;
             gameJoltUsername = original.gameJoltUsername;
             gameJoltToken = original.gameJoltToken;
 
@@ -80,6 +83,15 @@ namespace Sanicball.Data
         //they should be validated when loaded
         public void Validate()
         {
+            if (nickname == null)
+            {
+                nickname = string.Empty;
+            }
+            else
+            {
+                nickname = nickname.Trim();
+            }
+
             //Resolution
             if (resolution >= Screen.resolutions.Length)
                 resolution = Screen.resolutions.Length - 1;
@@ -94,6 +106,25 @@ namespace Sanicball.Data
             oldControlsKbSpeed = Mathf.Clamp(oldControlsKbSpeed, 0.5f, 10f);
             //Sound volume
             soundVolume = Mathf.Clamp(soundVolume, 0f, 1f);
+
+            //Server browser URL
+            if (string.IsNullOrWhiteSpace(serverListURL))
+            {
+                serverListURL = DefaultServerListUrl;
+            }
+            else
+            {
+                var trimmedUrl = serverListURL.Trim();
+                Uri parsedUri;
+                if (Uri.TryCreate(trimmedUrl, UriKind.Absolute, out parsedUri))
+                {
+                    serverListURL = trimmedUrl;
+                }
+                else
+                {
+                    serverListURL = DefaultServerListUrl;
+                }
+            }
         }
 
         public void Apply(bool changeWindow)

--- a/Assets/Scripts/Logic/MatchManager.cs
+++ b/Assets/Scripts/Logic/MatchManager.cs
@@ -367,7 +367,13 @@ namespace Sanicball.Logic
 
             //Create this client
             myGuid = Guid.NewGuid();
-            messenger.SendMessage(new ClientJoinedMessage(myGuid, ActiveData.GameSettings.nickname));
+            string nickname = ActiveData.GameSettings.nickname;
+            if (string.IsNullOrEmpty(nickname))
+            {
+                nickname = "Player";
+            }
+
+            messenger.SendMessage(new ClientJoinedMessage(myGuid, nickname));
         }
 
         private void LocalChatMessageSent(object sender, UI.ChatMessageArgs args)

--- a/Assets/Scripts/Startup.cs
+++ b/Assets/Scripts/Startup.cs
@@ -12,10 +12,12 @@ namespace Sanicball
 
         public void ValidateNickname()
         {
-            if (nicknameField.text.Trim() != "")
+            string trimmedNickname = nicknameField.text.Trim();
+            if (trimmedNickname != "")
             {
                 setNicknameGroup.alpha = 0f;
-                ActiveData.GameSettings.nickname = nicknameField.text;
+                ActiveData.GameSettings.nickname = trimmedNickname;
+                ActiveData.SaveGameSettings();
                 intro.enabled = true;
             }
         }

--- a/Assets/Scripts/UI/OnlinePanel.cs
+++ b/Assets/Scripts/UI/OnlinePanel.cs
@@ -35,10 +35,40 @@ namespace Sanicball.UI
             discoveryClient.DiscoverLocalPeers(25000);
             latestLocalRefreshTime = DateTime.Now;
 
-			serverBrowserRequester = new WWW(ActiveData.GameSettings.serverListURL);
+            var serverListUrl = ActiveData.GameSettings.serverListURL;
+            serverListUrl = string.IsNullOrWhiteSpace(serverListUrl) ? string.Empty : serverListUrl.Trim();
 
-            serverCountField.text = "Refreshing servers, hang on...";
-            errorField.enabled = false;
+            bool requestedBrowser = false;
+
+            if (string.IsNullOrEmpty(serverListUrl))
+            {
+                serverBrowserRequester = null;
+                errorField.enabled = true;
+                errorField.text = "Server list URL is empty. Update it in Options > Online.";
+                serverCountField.text = "Showing LAN servers only.";
+            }
+            else
+            {
+                try
+                {
+                    serverBrowserRequester = new WWW(serverListUrl);
+                    requestedBrowser = true;
+                }
+                catch (Exception ex)
+                {
+                    serverBrowserRequester = null;
+                    errorField.enabled = true;
+                    errorField.text = "Server list URL is invalid. Update it in Options > Online.";
+                    serverCountField.text = "Cannot access server list URL!";
+                    Debug.LogError("Failed to request servers from '" + serverListUrl + "' - " + ex.Message);
+                }
+            }
+
+            if (requestedBrowser)
+            {
+                serverCountField.text = "Refreshing servers, hang on...";
+                errorField.enabled = false;
+            }
 
             //Clear old servers
             foreach (var serv in servers)

--- a/Assets/Scripts/UI/OptionsPanel.cs
+++ b/Assets/Scripts/UI/OptionsPanel.cs
@@ -43,8 +43,11 @@ namespace Sanicball.UI
 
         public void Apply()
         {
+            tempSettings.Validate();
             ActiveData.GameSettings.CopyValues(tempSettings);
+            ActiveData.GameSettings.Validate();
             ActiveData.GameSettings.Apply(true);
+            ActiveData.SaveGameSettings();
         }
 
         public void RevertToCurrent()

--- a/Assets/Scripts/UI/WaitingUI.cs
+++ b/Assets/Scripts/UI/WaitingUI.cs
@@ -25,6 +25,7 @@ namespace Sanicball.UI
             if (Input.GetKeyDown(KeyCode.F1) || Input.GetKeyDown(KeyCode.JoystickButton6))
             {
                 ActiveData.GameSettings.showControlsWhileWaiting = !ActiveData.GameSettings.showControlsWhileWaiting;
+                ActiveData.SaveGameSettings();
             }
 
             controlsPanel.alpha = Mathf.Lerp(controlsPanel.alpha, ActiveData.GameSettings.showControlsWhileWaiting ? 1 : 0, Time.deltaTime * 20);


### PR DESCRIPTION
## Summary
- add a default constant and validation for the server browser URL in `GameSettings`
- validate loaded and applied settings so the URL is restored when blank or malformed
- guard the online server refresh logic against missing URLs and surface user-friendly errors
- persist `GameSettings` updates (nickname, waiting-screen toggle, GameJolt auth) immediately, trim stored nicknames, and fall back to "Player" when joining online without one

## Testing
- not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ceceab0c2c8325bc658f6d7f654ce9